### PR TITLE
[Core] Needle을 사용하여 프로젝트 의존성 구조를 변경했어요.

### DIFF
--- a/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
+++ b/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		EE4A181F27CB5B6C005752A7 /* HomeDetatilViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181E27CB5B6C005752A7 /* HomeDetatilViewController.swift */; };
 		EE6578C627F5EDCF0048F92D /* LoginFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6578C527F5EDCF0048F92D /* LoginFlowComponent.swift */; };
 		EE6578C827F5F0460048F92D /* MainFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6578C727F5F0460048F92D /* MainFlowComponent.swift */; };
-		EE6578CA27F5F5AA0048F92D /* HomeFlowComponenet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */; };
+		EE6578CA27F5F5AA0048F92D /* HomeFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6578C927F5F5AA0048F92D /* HomeFlowComponent.swift */; };
 		F741049027BB33B5002694E7 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F741048F27BB33B5002694E7 /* HomeCell.swift */; };
 		F7A5B22627B5DC8800152676 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A5B22527B5DC8800152676 /* AppDelegate.swift */; };
 		F7A5B22827B5DC8800152676 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A5B22727B5DC8800152676 /* SceneDelegate.swift */; };
@@ -101,7 +101,7 @@
 		EE4A181E27CB5B6C005752A7 /* HomeDetatilViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetatilViewController.swift; sourceTree = "<group>"; };
 		EE6578C527F5EDCF0048F92D /* LoginFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFlowComponent.swift; sourceTree = "<group>"; };
 		EE6578C727F5F0460048F92D /* MainFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlowComponent.swift; sourceTree = "<group>"; };
-		EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlowComponenet.swift; sourceTree = "<group>"; };
+		EE6578C927F5F5AA0048F92D /* HomeFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlowComponent.swift; sourceTree = "<group>"; };
 		F25C318A4F3C29B4BC5B6174 /* Pods-RxFlowWithReactorKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxFlowWithReactorKitTests.release.xcconfig"; path = "Target Support Files/Pods-RxFlowWithReactorKitTests/Pods-RxFlowWithReactorKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		F741048F27BB33B5002694E7 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		F7A5B22227B5DC8800152676 /* RxFlowWithReactorKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RxFlowWithReactorKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -211,7 +211,7 @@
 				EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */,
 				EE6578C527F5EDCF0048F92D /* LoginFlowComponent.swift */,
 				EE6578C727F5F0460048F92D /* MainFlowComponent.swift */,
-				EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */,
+				EE6578C927F5F5AA0048F92D /* HomeFlowComponent.swift */,
 				EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */,
 				EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */,
 				EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */,
@@ -702,7 +702,7 @@
 				F7FBD06827B9F36E002265FD /* SettingViewController.swift in Sources */,
 				EE28F6F827F8281C00E0A906 /* MiddleComponent.swift in Sources */,
 				EE1A164727F1D84500E87D4C /* ServiceProviderComponent.swift in Sources */,
-				EE6578CA27F5F5AA0048F92D /* HomeFlowComponenet.swift in Sources */,
+				EE6578CA27F5F5AA0048F92D /* HomeFlowComponent.swift in Sources */,
 				F7A5B28D27B5E07A00152676 /* NetworkManager.swift in Sources */,
 				F7A5B2A027B5EC2000152676 /* Step+asSample.swift in Sources */,
 				F7A5B2B227B63C3D00152676 /* HomeReactor.swift in Sources */,

--- a/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
+++ b/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		EE28F6F827F8281C00E0A906 /* MiddleComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */; };
 		EE28F6FA27F82AD900E0A906 /* MiddleDetailComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */; };
 		EE28F6FC27F82D0800E0A906 /* SettingFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6FB27F82D0800E0A906 /* SettingFlowComponent.swift */; };
+		EE28F6FE27F82E1900E0A906 /* SettingComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6FD27F82E1900E0A906 /* SettingComponent.swift */; };
 		EE4A181927CB56B5005752A7 /* MiddleDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */; };
 		EE4A181B27CB56F0005752A7 /* MiddleDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */; };
 		EE4A181D27CB5B4D005752A7 /* HomeDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */; };
@@ -93,6 +94,7 @@
 		EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleComponent.swift; sourceTree = "<group>"; };
 		EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailComponent.swift; sourceTree = "<group>"; };
 		EE28F6FB27F82D0800E0A906 /* SettingFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingFlowComponent.swift; sourceTree = "<group>"; };
+		EE28F6FD27F82E1900E0A906 /* SettingComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingComponent.swift; sourceTree = "<group>"; };
 		EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailReactor.swift; sourceTree = "<group>"; };
 		EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailViewController.swift; sourceTree = "<group>"; };
 		EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailReactor.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */,
 				EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */,
 				EE28F6FB27F82D0800E0A906 /* SettingFlowComponent.swift */,
+				EE28F6FD27F82E1900E0A906 /* SettingComponent.swift */,
 			);
 			path = DI;
 			sourceTree = "<group>";
@@ -707,6 +710,7 @@
 				EE1A164027F1BF6C00E87D4C /* RootComponent.swift in Sources */,
 				F7A5B2A927B6304D00152676 /* LoginFlow.swift in Sources */,
 				F7FBD06A27B9F596002265FD /* SettingFlow.swift in Sources */,
+				EE28F6FE27F82E1900E0A906 /* SettingComponent.swift in Sources */,
 				F7A5B29627B5E09F00152676 /* BaseService.swift in Sources */,
 				EE1A164527F1C46500E87D4C /* NeedleGenerated.swift in Sources */,
 				EE28F6F627F825C700E0A906 /* MiddleFlowComponent.swift in Sources */,

--- a/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
+++ b/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		EE28F6F627F825C700E0A906 /* MiddleFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */; };
 		EE28F6F827F8281C00E0A906 /* MiddleComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */; };
 		EE28F6FA27F82AD900E0A906 /* MiddleDetailComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */; };
+		EE28F6FC27F82D0800E0A906 /* SettingFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6FB27F82D0800E0A906 /* SettingFlowComponent.swift */; };
 		EE4A181927CB56B5005752A7 /* MiddleDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */; };
 		EE4A181B27CB56F0005752A7 /* MiddleDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */; };
 		EE4A181D27CB5B4D005752A7 /* HomeDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */; };
@@ -91,6 +92,7 @@
 		EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleFlowComponent.swift; sourceTree = "<group>"; };
 		EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleComponent.swift; sourceTree = "<group>"; };
 		EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailComponent.swift; sourceTree = "<group>"; };
+		EE28F6FB27F82D0800E0A906 /* SettingFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingFlowComponent.swift; sourceTree = "<group>"; };
 		EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailReactor.swift; sourceTree = "<group>"; };
 		EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailViewController.swift; sourceTree = "<group>"; };
 		EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailReactor.swift; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 				EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */,
 				EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */,
 				EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */,
+				EE28F6FB27F82D0800E0A906 /* SettingFlowComponent.swift */,
 			);
 			path = DI;
 			sourceTree = "<group>";
@@ -727,6 +730,7 @@
 				F7FBD06327B9CDE2002265FD /* MiddleFlow.swift in Sources */,
 				F7A5B29527B5E09F00152676 /* ServiceProvider.swift in Sources */,
 				EE4A181927CB56B5005752A7 /* MiddleDetailReactor.swift in Sources */,
+				EE28F6FC27F82D0800E0A906 /* SettingFlowComponent.swift in Sources */,
 				F7FBD06127B9C9E0002265FD /* MiddleViewController.swift in Sources */,
 				F7A5B29427B5E09F00152676 /* NetworkService.swift in Sources */,
 				F7A5B28427B5E05800152676 /* Cell+ReusableID.swift in Sources */,

--- a/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
+++ b/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		EE1A164927F1D86600E87D4C /* AppFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */; };
 		EE28F6F627F825C700E0A906 /* MiddleFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */; };
 		EE28F6F827F8281C00E0A906 /* MiddleComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */; };
+		EE28F6FA27F82AD900E0A906 /* MiddleDetailComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */; };
 		EE4A181927CB56B5005752A7 /* MiddleDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */; };
 		EE4A181B27CB56F0005752A7 /* MiddleDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */; };
 		EE4A181D27CB5B4D005752A7 /* HomeDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */; };
@@ -89,6 +90,7 @@
 		EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowComponent.swift; sourceTree = "<group>"; };
 		EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleFlowComponent.swift; sourceTree = "<group>"; };
 		EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleComponent.swift; sourceTree = "<group>"; };
+		EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailComponent.swift; sourceTree = "<group>"; };
 		EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailReactor.swift; sourceTree = "<group>"; };
 		EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailViewController.swift; sourceTree = "<group>"; };
 		EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailReactor.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 				EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */,
 				EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */,
 				EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */,
+				EE28F6F927F82AD900E0A906 /* MiddleDetailComponent.swift */,
 			);
 			path = DI;
 			sourceTree = "<group>";
@@ -686,6 +689,7 @@
 				F7FBD06627B9DF7B002265FD /* SettingReactor.swift in Sources */,
 				F7A5B2B427B63C6F00152676 /* HomeViewController.swift in Sources */,
 				F7A5B2AF27B63BB900152676 /* HomeFlow.swift in Sources */,
+				EE28F6FA27F82AD900E0A906 /* MiddleDetailComponent.swift in Sources */,
 				F7A5B22627B5DC8800152676 /* AppDelegate.swift in Sources */,
 				F7A5B28327B5E05800152676 /* UIView+safeArea.swift in Sources */,
 				EE1A164927F1D86600E87D4C /* AppFlowComponent.swift in Sources */,

--- a/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
+++ b/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		EE4A181B27CB56F0005752A7 /* MiddleDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */; };
 		EE4A181D27CB5B4D005752A7 /* HomeDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */; };
 		EE4A181F27CB5B6C005752A7 /* HomeDetatilViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181E27CB5B6C005752A7 /* HomeDetatilViewController.swift */; };
+		EE6578C627F5EDCF0048F92D /* LoginFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6578C527F5EDCF0048F92D /* LoginFlowComponent.swift */; };
+		EE6578C827F5F0460048F92D /* MainFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6578C727F5F0460048F92D /* MainFlowComponent.swift */; };
+		EE6578CA27F5F5AA0048F92D /* HomeFlowComponenet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */; };
 		F741049027BB33B5002694E7 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F741048F27BB33B5002694E7 /* HomeCell.swift */; };
 		F7A5B22627B5DC8800152676 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A5B22527B5DC8800152676 /* AppDelegate.swift */; };
 		F7A5B22827B5DC8800152676 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A5B22727B5DC8800152676 /* SceneDelegate.swift */; };
@@ -86,6 +89,9 @@
 		EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailViewController.swift; sourceTree = "<group>"; };
 		EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailReactor.swift; sourceTree = "<group>"; };
 		EE4A181E27CB5B6C005752A7 /* HomeDetatilViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetatilViewController.swift; sourceTree = "<group>"; };
+		EE6578C527F5EDCF0048F92D /* LoginFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFlowComponent.swift; sourceTree = "<group>"; };
+		EE6578C727F5F0460048F92D /* MainFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlowComponent.swift; sourceTree = "<group>"; };
+		EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFlowComponenet.swift; sourceTree = "<group>"; };
 		F25C318A4F3C29B4BC5B6174 /* Pods-RxFlowWithReactorKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxFlowWithReactorKitTests.release.xcconfig"; path = "Target Support Files/Pods-RxFlowWithReactorKitTests/Pods-RxFlowWithReactorKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		F741048F27BB33B5002694E7 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		F7A5B22227B5DC8800152676 /* RxFlowWithReactorKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RxFlowWithReactorKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -193,6 +199,9 @@
 				EE1A163F27F1BF6C00E87D4C /* RootComponent.swift */,
 				EE1A164627F1D84500E87D4C /* ServiceProviderComponent.swift */,
 				EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */,
+				EE6578C527F5EDCF0048F92D /* LoginFlowComponent.swift */,
+				EE6578C727F5F0460048F92D /* MainFlowComponent.swift */,
+				EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */,
 			);
 			path = DI;
 			sourceTree = "<group>";
@@ -676,6 +685,7 @@
 				EE1A164927F1D86600E87D4C /* AppFlowComponent.swift in Sources */,
 				F7FBD06827B9F36E002265FD /* SettingViewController.swift in Sources */,
 				EE1A164727F1D84500E87D4C /* ServiceProviderComponent.swift in Sources */,
+				EE6578CA27F5F5AA0048F92D /* HomeFlowComponenet.swift in Sources */,
 				F7A5B28D27B5E07A00152676 /* NetworkManager.swift in Sources */,
 				F7A5B2A027B5EC2000152676 /* Step+asSample.swift in Sources */,
 				F7A5B2B227B63C3D00152676 /* HomeReactor.swift in Sources */,
@@ -694,6 +704,8 @@
 				F741049027BB33B5002694E7 /* HomeCell.swift in Sources */,
 				F7A5B28827B5E05800152676 /* Models.swift in Sources */,
 				EE4A181F27CB5B6C005752A7 /* HomeDetatilViewController.swift in Sources */,
+				EE6578C827F5F0460048F92D /* MainFlowComponent.swift in Sources */,
+				EE6578C627F5EDCF0048F92D /* LoginFlowComponent.swift in Sources */,
 				F7A5B29E27B5E9ED00152676 /* AppFlow.swift in Sources */,
 				F7A5B29B27B5E17800152676 /* SampleStep.swift in Sources */,
 				F7A5B28527B5E05800152676 /* Observable+Extensions.swift in Sources */,

--- a/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
+++ b/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		EE1A164527F1C46500E87D4C /* NeedleGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1A164427F1C46500E87D4C /* NeedleGenerated.swift */; };
 		EE1A164727F1D84500E87D4C /* ServiceProviderComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1A164627F1D84500E87D4C /* ServiceProviderComponent.swift */; };
 		EE1A164927F1D86600E87D4C /* AppFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */; };
+		EE28F6F627F825C700E0A906 /* MiddleFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */; };
 		EE4A181927CB56B5005752A7 /* MiddleDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */; };
 		EE4A181B27CB56F0005752A7 /* MiddleDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */; };
 		EE4A181D27CB5B4D005752A7 /* HomeDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */; };
@@ -85,6 +86,7 @@
 		EE1A164427F1C46500E87D4C /* NeedleGenerated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NeedleGenerated.swift; sourceTree = "<group>"; };
 		EE1A164627F1D84500E87D4C /* ServiceProviderComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProviderComponent.swift; sourceTree = "<group>"; };
 		EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowComponent.swift; sourceTree = "<group>"; };
+		EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleFlowComponent.swift; sourceTree = "<group>"; };
 		EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailReactor.swift; sourceTree = "<group>"; };
 		EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailViewController.swift; sourceTree = "<group>"; };
 		EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailReactor.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 				EE6578C527F5EDCF0048F92D /* LoginFlowComponent.swift */,
 				EE6578C727F5F0460048F92D /* MainFlowComponent.swift */,
 				EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */,
+				EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */,
 			);
 			path = DI;
 			sourceTree = "<group>";
@@ -695,6 +698,7 @@
 				F7FBD06A27B9F596002265FD /* SettingFlow.swift in Sources */,
 				F7A5B29627B5E09F00152676 /* BaseService.swift in Sources */,
 				EE1A164527F1C46500E87D4C /* NeedleGenerated.swift in Sources */,
+				EE28F6F627F825C700E0A906 /* MiddleFlowComponent.swift in Sources */,
 				F7A5B22827B5DC8800152676 /* SceneDelegate.swift in Sources */,
 				EE4A181B27CB56F0005752A7 /* MiddleDetailViewController.swift in Sources */,
 				F7A5B2AC27B6386E00152676 /* MainFlow.swift in Sources */,

--- a/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
+++ b/starter/RxFlowWithReactorKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		EE1A164727F1D84500E87D4C /* ServiceProviderComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1A164627F1D84500E87D4C /* ServiceProviderComponent.swift */; };
 		EE1A164927F1D86600E87D4C /* AppFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */; };
 		EE28F6F627F825C700E0A906 /* MiddleFlowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */; };
+		EE28F6F827F8281C00E0A906 /* MiddleComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */; };
 		EE4A181927CB56B5005752A7 /* MiddleDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */; };
 		EE4A181B27CB56F0005752A7 /* MiddleDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */; };
 		EE4A181D27CB5B4D005752A7 /* HomeDetailReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */; };
@@ -87,6 +88,7 @@
 		EE1A164627F1D84500E87D4C /* ServiceProviderComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProviderComponent.swift; sourceTree = "<group>"; };
 		EE1A164827F1D86600E87D4C /* AppFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowComponent.swift; sourceTree = "<group>"; };
 		EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleFlowComponent.swift; sourceTree = "<group>"; };
+		EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleComponent.swift; sourceTree = "<group>"; };
 		EE4A181827CB56B5005752A7 /* MiddleDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailReactor.swift; sourceTree = "<group>"; };
 		EE4A181A27CB56F0005752A7 /* MiddleDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiddleDetailViewController.swift; sourceTree = "<group>"; };
 		EE4A181C27CB5B4D005752A7 /* HomeDetailReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailReactor.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 				EE6578C727F5F0460048F92D /* MainFlowComponent.swift */,
 				EE6578C927F5F5AA0048F92D /* HomeFlowComponenet.swift */,
 				EE28F6F527F825C700E0A906 /* MiddleFlowComponent.swift */,
+				EE28F6F727F8281C00E0A906 /* MiddleComponent.swift */,
 			);
 			path = DI;
 			sourceTree = "<group>";
@@ -687,6 +690,7 @@
 				F7A5B28327B5E05800152676 /* UIView+safeArea.swift in Sources */,
 				EE1A164927F1D86600E87D4C /* AppFlowComponent.swift in Sources */,
 				F7FBD06827B9F36E002265FD /* SettingViewController.swift in Sources */,
+				EE28F6F827F8281C00E0A906 /* MiddleComponent.swift in Sources */,
 				EE1A164727F1D84500E87D4C /* ServiceProviderComponent.swift in Sources */,
 				EE6578CA27F5F5AA0048F92D /* HomeFlowComponenet.swift in Sources */,
 				F7A5B28D27B5E07A00152676 /* NetworkManager.swift in Sources */,

--- a/starter/RxFlowWithReactorKit/Sources/Core/SceneDelegate.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Core/SceneDelegate.swift
@@ -21,9 +21,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 		// Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
 		// If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
 		// This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+		registerProviderFactories()
+		
 		guard let windowScene = (scene as? UIWindowScene) else { return }
-    
-    registerProviderFactories()
 		
 		coordinatorLogStart()
 		
@@ -68,14 +68,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 extension SceneDelegate {
 	private func coordinateToAppFlow(with windowScene: UIWindowScene) {
 		let window = UIWindow(windowScene: windowScene)
+		self.window = window
 		
-		let rootComponent = RootComponent(window: window)
+		let rootComponent = RootComponent()
 		
-    coordinator.coordinate(flow: rootComponent.appFlowBuilder.flow, with: rootComponent.appFlowBuilder.stepper)
+		let appFlow = rootComponent.appFlowBuilder.flow
+		let appStepper = rootComponent.appFlowBuilder.stepper
 		
-		window.makeKeyAndVisible()
-    
-    self.window = window
+		appFlow.launch(from: window)
+		
+		coordinator.coordinate(flow: appFlow, with: appStepper)
 	}
 	
 	private func coordinatorLogStart() {

--- a/starter/RxFlowWithReactorKit/Sources/DI/AppFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/AppFlowComponent.swift
@@ -10,21 +10,30 @@ import NeedleFoundation
 import RxFlow
 
 protocol AppFlowDependency: Dependency {
-  var window: UIWindow { get }
-  var serviceBuilder: ServiceProviderBuilder { get }
+	var serviceBuilder: ServiceProviderBuilder { get }
 }
 
 protocol AppFlowComponentBuilder {
-  var flow: Flow { get }
-  var stepper: Stepper { get }
+	var flow: AppFlow { get }
+	var stepper: Stepper { get }
+	var loginBuidler: LoginFlowComponentBuilder { get }
+	var mainBuilder: MainFlowComponentBuilder { get }
 }
 
 class AppFlowComponent: Component<AppFlowDependency>, AppFlowComponentBuilder {
-  var flow: Flow {
-    return AppFlow(with: self.window, and: self.serviceBuilder.provider)
-  }
-  
-  var stepper: Stepper {
-    return AppStepper(provider: self.serviceBuilder.provider)
-  }
+	var flow: AppFlow {
+		return AppFlow(dependency: self)
+	}
+	
+	var stepper: Stepper {
+		return AppStepper(provider: self.serviceBuilder.provider)
+	}
+	
+	var loginBuidler: LoginFlowComponentBuilder {
+		return LoginFlowComponent(parent: self)
+	}
+	
+	var mainBuilder: MainFlowComponentBuilder {
+		return MainFlowComponent(parent: self)
+	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/DI/HomeFlowComponenet.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/HomeFlowComponenet.swift
@@ -1,0 +1,64 @@
+//
+//  HomeFlowComponenet.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/03/31.
+//
+
+import UIKit
+import NeedleFoundation
+import RxFlow
+
+protocol HomeFlowDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol HomeFlowComponenetBuilder {
+	var flow: HomeFlow { get }
+	var homeBuilder: HomeComponentBuilder { get }
+	var homeDetailBuilder: HomeDetailBuilder { get }
+}
+
+class HomeFlowComponenet: Component<LoginFlowDependency>, HomeFlowComponenetBuilder {
+	var flow: HomeFlow {
+		return HomeFlow(dependency: self, stepper: .init())
+	}
+	
+	var homeBuilder: HomeComponentBuilder {
+		return HomeComponenet(parent: self)
+	}
+	
+	var homeDetailBuilder: HomeDetailBuilder {
+		return HomeDetailComponent(parent: self)
+	}
+}
+
+protocol HomeDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol HomeComponentBuilder {
+	var homeViewController: HomeViewController { get }
+}
+
+class HomeComponenet: Component<HomeDependency>, HomeComponentBuilder {
+	var homeViewController: HomeViewController {
+		let reactor = HomeReactor(provider: self.dependency.serviceBuilder.provider)
+		return HomeViewController(with: reactor)
+	}
+}
+
+protocol HomeDetailDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol HomeDetailBuilder {
+	func makeDetailViewController(title: String) -> HomeDetatilViewController
+}
+
+class HomeDetailComponent: Component<HomeDetailDependency>, HomeDetailBuilder {
+	func makeDetailViewController(title: String) -> HomeDetatilViewController {
+		let reactor = HomeDetailReactor(provider: self.dependency.serviceBuilder.provider)
+		return HomeDetatilViewController(with: reactor, title: title)
+	}
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/HomeFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/HomeFlowComponent.swift
@@ -1,5 +1,5 @@
 //
-//  HomeFlowComponenet.swift
+//  HomeFlowComponent.swift
 //  RxFlowWithReactorKit
 //
 //  Created by Lyine on 2022/03/31.
@@ -13,13 +13,13 @@ protocol HomeFlowDependency: Dependency {
 	var serviceBuilder: ServiceProviderBuilder { get }
 }
 
-protocol HomeFlowComponenetBuilder {
+protocol HomeFlowComponentBuilder {
 	var flow: HomeFlow { get }
 	var homeBuilder: HomeComponentBuilder { get }
 	var homeDetailBuilder: HomeDetailBuilder { get }
 }
 
-class HomeFlowComponenet: Component<LoginFlowDependency>, HomeFlowComponenetBuilder {
+class HomeFlowComponent: Component<LoginFlowDependency>, HomeFlowComponentBuilder {
 	var flow: HomeFlow {
 		return HomeFlow(dependency: self, stepper: .init())
 	}

--- a/starter/RxFlowWithReactorKit/Sources/DI/HomeFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/HomeFlowComponent.swift
@@ -25,7 +25,7 @@ class HomeFlowComponent: Component<LoginFlowDependency>, HomeFlowComponentBuilde
 	}
 	
 	var homeBuilder: HomeComponentBuilder {
-		return HomeComponenet(parent: self)
+		return HomeComponent(parent: self)
 	}
 	
 	var homeDetailBuilder: HomeDetailBuilder {
@@ -41,7 +41,7 @@ protocol HomeComponentBuilder {
 	var homeViewController: HomeViewController { get }
 }
 
-class HomeComponenet: Component<HomeDependency>, HomeComponentBuilder {
+class HomeComponent: Component<HomeDependency>, HomeComponentBuilder {
 	var homeViewController: HomeViewController {
 		let reactor = HomeReactor(provider: self.dependency.serviceBuilder.provider)
 		return HomeViewController(with: reactor)

--- a/starter/RxFlowWithReactorKit/Sources/DI/LoginFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/LoginFlowComponent.swift
@@ -1,0 +1,45 @@
+//
+//  LoginFlowComponent.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/03/31.
+//
+
+import UIKit
+import NeedleFoundation
+import RxFlow
+
+protocol LoginFlowDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol LoginFlowComponentBuilder {
+	var flow: LoginFlow { get }
+	var loginBuilder: LoginComponentBuilder { get }
+}
+
+class LoginFlowComponent: Component<LoginFlowDependency>, LoginFlowComponentBuilder {
+	var flow: LoginFlow {
+		return LoginFlow(with: self.dependency.serviceBuilder.provider, builder: self.loginBuilder)
+	}
+	
+	var loginBuilder: LoginComponentBuilder {
+		return LoginComponent(parent: self)
+	}
+}
+
+
+protocol LoginDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol LoginComponentBuilder {
+	var viewController: LoginVC { get }
+}
+
+class LoginComponent: Component<LoginFlowDependency>, LoginComponentBuilder {
+	var viewController: LoginVC {
+		let reactor = LoginReactor(dependency: .init(provider: self.dependency.serviceBuilder.provider))
+		return LoginVC(with: reactor)
+	}
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
@@ -17,6 +17,7 @@ protocol MainFlowComponentBuilder {
 	var flow: Flow { get }
 	var homeFlowBuilder: HomeFlowComponenetBuilder { get }
 	var middleFlowBuilder: MiddleFlowComponentBuilder { get }
+	var settingFlowBuilder: SettingFlowComponentBuilder { get }
 }
 
 class MainFlowComponent: Component<MainFlowDependency>, MainFlowComponentBuilder {
@@ -30,5 +31,9 @@ class MainFlowComponent: Component<MainFlowDependency>, MainFlowComponentBuilder
 	
 	var middleFlowBuilder: MiddleFlowComponentBuilder {
 		return MiddleFlowComponent(parent: self)
+	}
+	
+	var settingFlowBuilder: SettingFlowComponentBuilder {
+		return SettingFlowComponent(parent: self)
 	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
@@ -1,0 +1,29 @@
+//
+//  MainFlowComponent.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/03/31.
+//
+
+import UIKit
+import NeedleFoundation
+import RxFlow
+
+protocol MainFlowDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol MainFlowComponentBuilder {
+	var flow: Flow { get }
+	var homeFlowBuilder: HomeFlowComponenetBuilder { get }
+}
+
+class MainFlowComponent: Component<MainFlowDependency>, MainFlowComponentBuilder {
+	var flow: Flow {
+		return MainFlow(dependency: self)
+	}
+	
+	var homeFlowBuilder: HomeFlowComponenetBuilder {
+		return HomeFlowComponenet(parent: self)
+	}
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
@@ -15,7 +15,7 @@ protocol MainFlowDependency: Dependency {
 
 protocol MainFlowComponentBuilder {
 	var flow: Flow { get }
-	var homeFlowBuilder: HomeFlowComponenetBuilder { get }
+	var homeFlowBuilder: HomeFlowComponentBuilder { get }
 	var middleFlowBuilder: MiddleFlowComponentBuilder { get }
 	var settingFlowBuilder: SettingFlowComponentBuilder { get }
 }
@@ -25,8 +25,8 @@ class MainFlowComponent: Component<MainFlowDependency>, MainFlowComponentBuilder
 		return MainFlow(dependency: self)
 	}
 	
-	var homeFlowBuilder: HomeFlowComponenetBuilder {
-		return HomeFlowComponenet(parent: self)
+	var homeFlowBuilder: HomeFlowComponentBuilder {
+		return HomeFlowComponent(parent: self)
 	}
 	
 	var middleFlowBuilder: MiddleFlowComponentBuilder {

--- a/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MainFlowComponent.swift
@@ -16,6 +16,7 @@ protocol MainFlowDependency: Dependency {
 protocol MainFlowComponentBuilder {
 	var flow: Flow { get }
 	var homeFlowBuilder: HomeFlowComponenetBuilder { get }
+	var middleFlowBuilder: MiddleFlowComponentBuilder { get }
 }
 
 class MainFlowComponent: Component<MainFlowDependency>, MainFlowComponentBuilder {
@@ -25,5 +26,9 @@ class MainFlowComponent: Component<MainFlowDependency>, MainFlowComponentBuilder
 	
 	var homeFlowBuilder: HomeFlowComponenetBuilder {
 		return HomeFlowComponenet(parent: self)
+	}
+	
+	var middleFlowBuilder: MiddleFlowComponentBuilder {
+		return MiddleFlowComponent(parent: self)
 	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/DI/MiddleComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MiddleComponent.swift
@@ -1,0 +1,24 @@
+//
+//  MiddleComponent.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/04/02.
+//
+
+import Foundation
+import NeedleFoundation
+
+protocol MiddleDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol MiddleComponentBuilder {
+	var viewController: MiddleViewController { get }
+}
+
+class MiddleComponent: Component<MiddleDependency>, MiddleComponentBuilder {
+	var viewController: MiddleViewController {
+		let reactor = MiddleReactor(provider: self.dependency.serviceBuilder.provider)
+		return MiddleViewController(with: reactor)
+	}
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/MiddleDetailComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MiddleDetailComponent.swift
@@ -12,8 +12,13 @@ protocol MiddleDetailDependency: Dependency {
 	var serviceBuilder: ServiceProviderBuilder { get }
 }
 
-protocol MiddleDetailComponentBuilder {}
+protocol MiddleDetailComponentBuilder {
+	var viewController: MiddleDetailViewContorller { get }
+}
 
 class MiddleDetailComponent: Component<MiddleDetailDependency>, MiddleDetailComponentBuilder {
-	
+	var viewController: MiddleDetailViewContorller {
+		let reactor = MiddleDetailReactor(provider: self.dependency.serviceBuilder.provider)
+		return MiddleDetailViewContorller(with: reactor)
+	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/DI/MiddleDetailComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MiddleDetailComponent.swift
@@ -1,0 +1,19 @@
+//
+//  MiddleDetailComponent.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/04/02.
+//
+
+import Foundation
+import NeedleFoundation
+
+protocol MiddleDetailDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol MiddleDetailComponentBuilder {}
+
+class MiddleDetailComponent: Component<MiddleDetailDependency>, MiddleDetailComponentBuilder {
+	
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/MiddleFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MiddleFlowComponent.swift
@@ -15,6 +15,7 @@ protocol MiddleFlowDependency: Dependency {
 protocol MiddleFlowComponentBuilder {
 	var flow: MiddleFlow { get }
 	var middleBuilder: MiddleComponentBuilder { get }
+	var detailBuilder: MiddleDetailComponentBuilder { get }
 }
 
 class MiddleFlowComponent: Component<MiddleFlowDependency>, MiddleFlowComponentBuilder {
@@ -24,5 +25,9 @@ class MiddleFlowComponent: Component<MiddleFlowDependency>, MiddleFlowComponentB
 	
 	var middleBuilder: MiddleComponentBuilder {
 		return MiddleComponent(parent: self)
+	}
+	
+	var detailBuilder: MiddleDetailComponentBuilder {
+		return MiddleDetailComponent(parent: self)
 	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/DI/MiddleFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MiddleFlowComponent.swift
@@ -1,0 +1,23 @@
+//
+//  MiddleFlowComponent.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/04/02.
+//
+
+import Foundation
+import NeedleFoundation
+
+protocol MiddleFlowDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
+
+protocol MiddleFlowComponentBuilder {
+	var flow: MiddleFlow { get }
+}
+
+class MiddleFlowComponent: Component<MiddleFlowDependency>, MiddleFlowComponentBuilder {
+	var flow: MiddleFlow {
+		return MiddleFlow(with: self, stepper: .init())
+	}
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/MiddleFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/MiddleFlowComponent.swift
@@ -14,10 +14,15 @@ protocol MiddleFlowDependency: Dependency {
 
 protocol MiddleFlowComponentBuilder {
 	var flow: MiddleFlow { get }
+	var middleBuilder: MiddleComponentBuilder { get }
 }
 
 class MiddleFlowComponent: Component<MiddleFlowDependency>, MiddleFlowComponentBuilder {
 	var flow: MiddleFlow {
 		return MiddleFlow(with: self, stepper: .init())
+	}
+	
+	var middleBuilder: MiddleComponentBuilder {
+		return MiddleComponent(parent: self)
 	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/DI/RootComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/RootComponent.swift
@@ -9,14 +9,7 @@ import UIKit
 import NeedleFoundation
 
 class RootComponent: BootstrapComponent {
-  
-  var window: UIWindow
-  
-  init(window: UIWindow) {
-    self.window = window
-    super.init()
-  }
-  
+	
   var userDefaults: UserDefaults {
     return UserDefaults.standard
   }

--- a/starter/RxFlowWithReactorKit/Sources/DI/ServiceProviderComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/ServiceProviderComponent.swift
@@ -19,8 +19,10 @@ protocol ServiceProviderBuilder {
 
 class ServiceComponent: Component<ServiceProviderDependency>, ServiceProviderBuilder {
   var provider: ServiceProviderType {
-    return ServiceProviderImpl(networkService: self.networkService,
-                               loginService: self.loginService)
+		shared {
+			ServiceProviderImpl(networkService: self.networkService,
+													loginService: self.loginService)
+		}
   }
   
   deinit {

--- a/starter/RxFlowWithReactorKit/Sources/DI/SettingComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/SettingComponent.swift
@@ -1,0 +1,15 @@
+//
+//  SettingComponent.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/04/02.
+//
+
+import Foundation
+import NeedleFoundation
+
+protocol SettingDependency: Dependency {}
+
+protocol SettingComponentBuilder {}
+
+class SettingComponent: Component<SettingDependency>, SettingComponentBuilder {}

--- a/starter/RxFlowWithReactorKit/Sources/DI/SettingComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/SettingComponent.swift
@@ -8,8 +8,17 @@
 import Foundation
 import NeedleFoundation
 
-protocol SettingDependency: Dependency {}
+protocol SettingDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
 
-protocol SettingComponentBuilder {}
+protocol SettingComponentBuilder {
+	var viewController: SettingViewController { get }
+}
 
-class SettingComponent: Component<SettingDependency>, SettingComponentBuilder {}
+class SettingComponent: Component<SettingDependency>, SettingComponentBuilder {
+	var viewController: SettingViewController {
+		let reactor = SettingReactor(provider: self.dependency.serviceBuilder.provider)
+		return SettingViewController(with: reactor)
+	}
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/SettingFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/SettingFlowComponent.swift
@@ -8,8 +8,16 @@
 import Foundation
 import NeedleFoundation
 
-protocol SettingFlowDependency: Dependency {}
+protocol SettingFlowDependency: Dependency {
+	var serviceBuilder: ServiceProviderBuilder { get }
+}
 
-protocol SettingFlowComponentBuilder {}
+protocol SettingFlowComponentBuilder {
+	var flow: SettingFlow { get }
+}
 
-class SettingFlowComponent: Component<SettingFlowDependency>, SettingFlowComponentBuilder {}
+class SettingFlowComponent: Component<SettingFlowDependency>, SettingFlowComponentBuilder {
+	var flow: SettingFlow {
+		return SettingFlow(dependency: self, stepper: .init())
+	}
+}

--- a/starter/RxFlowWithReactorKit/Sources/DI/SettingFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/SettingFlowComponent.swift
@@ -1,0 +1,15 @@
+//
+//  SettingFlowComponent.swift
+//  RxFlowWithReactorKit
+//
+//  Created by Lyine on 2022/04/02.
+//
+
+import Foundation
+import NeedleFoundation
+
+protocol SettingFlowDependency: Dependency {}
+
+protocol SettingFlowComponentBuilder {}
+
+class SettingFlowComponent: Component<SettingFlowDependency>, SettingFlowComponentBuilder {}

--- a/starter/RxFlowWithReactorKit/Sources/DI/SettingFlowComponent.swift
+++ b/starter/RxFlowWithReactorKit/Sources/DI/SettingFlowComponent.swift
@@ -14,10 +14,15 @@ protocol SettingFlowDependency: Dependency {
 
 protocol SettingFlowComponentBuilder {
 	var flow: SettingFlow { get }
+	var builder: SettingComponentBuilder { get }
 }
 
 class SettingFlowComponent: Component<SettingFlowDependency>, SettingFlowComponentBuilder {
 	var flow: SettingFlow {
 		return SettingFlow(dependency: self, stepper: .init())
+	}
+	
+	var builder: SettingComponentBuilder {
+		return SettingComponent(parent: self)
 	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Login/LoginFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Login/LoginFlow.swift
@@ -15,9 +15,14 @@ final class LoginFlow: Flow {
 	
 	private let rootViewController: UINavigationController = .init()
 	private let provider: ServiceProviderType
+	private let builder: LoginComponentBuilder
 	
-	init(with services: ServiceProviderType) {
+	init(
+		with services: ServiceProviderType,
+		builder: LoginComponentBuilder
+	) {
 		self.provider = services
+		self.builder = builder
 	}
 	
 	deinit {
@@ -37,11 +42,12 @@ final class LoginFlow: Flow {
 		}
 	}
 	
+	// builder를 통해 viewController와 reactor를 따로 생성하면 참조하는 메모리가 달라져서 서로 연결되지 않은 상태로 동작합니다.
+	// vc.reactor를 쓰던 viewController를 reactor로 생성해서 쓰던 방법을 강구해봐야 할 것 같아요.
 	private func coordinateToLogin() -> FlowContributors {
-		let reactor = LoginReactor(dependency: .init(provider: provider))
-		let vc = LoginVC(with: reactor)
+		let vc = self.builder.viewController
 		self.rootViewController.pushViewController(vc, animated: true)
 		return .one(flowContributor: .contribute(withNextPresentable: vc,
-																						 withNextStepper: reactor))
+																						 withNextStepper: vc.reactor!))
 	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/HomeFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/HomeFlow.swift
@@ -33,12 +33,12 @@ final class HomeFlow: Flow {
 	let stepper: HomeStepper
 	private let rootViewController = UINavigationController()
 	
-	private let dependency: HomeFlowComponenet
+	private let dependency: HomeFlowComponent
 	
 		// MARK: Init
 	
 	init(
-		dependency: HomeFlowComponenet,
+		dependency: HomeFlowComponent,
 		stepper: HomeStepper
 	) {
 		self.dependency = dependency

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/HomeFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/HomeFlow.swift
@@ -16,6 +16,10 @@ struct HomeStepper: Stepper {
 	var initialStep: Step {
 		return SampleStep.homeIsRequired
 	}
+	
+	func readyToEmitSteps() {
+		debugPrint(self)
+	}
 }
 
 final class HomeFlow: Flow {
@@ -27,16 +31,17 @@ final class HomeFlow: Flow {
 	}
 	
 	let stepper: HomeStepper
-	private let provider: ServiceProviderType
 	private let rootViewController = UINavigationController()
 	
-	// MARK: Init
+	private let dependency: HomeFlowComponenet
+	
+		// MARK: Init
 	
 	init(
-		with services: ServiceProviderType,
+		dependency: HomeFlowComponenet,
 		stepper: HomeStepper
 	) {
-		self.provider = services
+		self.dependency = dependency
 		self.stepper = stepper
 	}
 	
@@ -44,7 +49,7 @@ final class HomeFlow: Flow {
 		print("\(type(of: self)): \(#function)")
 	}
 	
-	// MARK: Navigate
+		// MARK: Navigate
 	
 	func navigate(to step: Step) -> FlowContributors {
 		guard let step = step.asSampleStep else { return .none }
@@ -62,23 +67,21 @@ final class HomeFlow: Flow {
 	}
 }
 
-// MARK: - Extensions
+	// MARK: - Extensions
 
 private extension HomeFlow {
 	func coordinateToHome() -> FlowContributors {
-		let reactor = HomeReactor(provider: provider)
-		let viewController = HomeViewController(with: reactor)
+		let viewController = self.dependency.homeBuilder.homeViewController
 		
 		self.rootViewController.setViewControllers([viewController], animated: true)
 		
-		return .one(flowContributor: .contribute(withNextPresentable: viewController, withNextStepper: reactor))
+		return .one(flowContributor: .contribute(withNextPresentable: viewController, withNextStepper: viewController.reactor!))
 	}
 	
 	func coordinateToHomeDetail(with ID: String) -> FlowContributors {
-		let reactor = HomeDetailReactor(provider: provider)
-		let vc = HomeDetatilViewController(with: reactor, title: ID)
-		self.rootViewController.pushViewController(vc, animated: true)
-		return .one(flowContributor: .contribute(withNextPresentable: vc,
-																						 withNextStepper: reactor))
+		let viewController = self.dependency.homeDetailBuilder.makeDetailViewController(title: ID)
+		self.rootViewController.pushViewController(viewController, animated: true)
+		return .one(flowContributor: .contribute(withNextPresentable: viewController,
+																						 withNextStepper: viewController.reactor!))
 	}
 }

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/MainFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/MainFlow.swift
@@ -29,7 +29,7 @@ final class MainFlow: Flow {
 	
 	init(dependency: MainFlowComponent) {
 		self.homeFlow = dependency.homeFlowBuilder.flow
-		self.middleFlow = .init(with: dependency.serviceBuilder.provider, stepper: .init())
+		self.middleFlow = dependency.middleFlowBuilder.flow
 		self.settingFlow = .init(with: dependency.serviceBuilder.provider, stepper: .init())
 	}
 	

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/MainFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/MainFlow.swift
@@ -22,19 +22,15 @@ final class MainFlow: Flow {
 		return self.rootViewController
 	}
 	
-	struct Dependency {
-		let provider: ServiceProviderType
-	}
-	
 	let rootViewController = UITabBarController()
 	let homeFlow: HomeFlow
 	let middleFlow: MiddleFlow
 	let settingFlow: SettingFlow
 	
-	init(dependency: Dependency) {
-		self.homeFlow = .init(with: dependency.provider, stepper: .init())
-		self.middleFlow = .init(with: dependency.provider, stepper: .init())
-		self.settingFlow = .init(with: dependency.provider, stepper: .init())
+	init(dependency: MainFlowComponent) {
+		self.homeFlow = dependency.homeFlowBuilder.flow
+		self.middleFlow = .init(with: dependency.serviceBuilder.provider, stepper: .init())
+		self.settingFlow = .init(with: dependency.serviceBuilder.provider, stepper: .init())
 	}
 	
 	func navigate(to step: Step) -> FlowContributors {
@@ -55,7 +51,7 @@ final class MainFlow: Flow {
 	}
 }
 
-// MARK: - Extensions
+	// MARK: - Extensions
 
 extension MainFlow {
 	private func coordinateToMainTabBar() -> FlowContributors {

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/MainFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/MainFlow.swift
@@ -30,7 +30,7 @@ final class MainFlow: Flow {
 	init(dependency: MainFlowComponent) {
 		self.homeFlow = dependency.homeFlowBuilder.flow
 		self.middleFlow = dependency.middleFlowBuilder.flow
-		self.settingFlow = .init(with: dependency.serviceBuilder.provider, stepper: .init())
+		self.settingFlow = dependency.settingFlowBuilder.flow
 	}
 	
 	func navigate(to step: Step) -> FlowContributors {

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/MiddleFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/MiddleFlow.swift
@@ -28,14 +28,14 @@ final class MiddleFlow: Flow {
 	
 	let stepper: MiddleStepper
 	
-	private let provider: ServiceProviderType
+	private let dependency: MiddleFlowComponent
 	
 	// MARK: Init
 	init(
-		with services: ServiceProviderType,
+		with dependency: MiddleFlowComponent,
 		stepper: MiddleStepper
 	) {
-		self.provider = services
+		self.dependency = dependency
 		self.stepper = stepper
 	}
 	
@@ -76,7 +76,7 @@ final class MiddleFlow: Flow {
 
 private extension MiddleFlow {
 	func coordinateToMiddle() -> FlowContributors {
-		let reactor = MiddleReactor(provider: provider)
+		let reactor = MiddleReactor(provider: self.dependency.serviceBuilder.provider)
 		let vc = MiddleViewController(with: reactor)
 		self.rootViewController.setViewControllers([vc], animated: true)
 		return .one(flowContributor: .contribute(withNextPresentable: vc,
@@ -92,7 +92,7 @@ private extension MiddleFlow {
 	}
 	
 	func presentMiddleDetail() -> FlowContributors {
-		let reactor = MiddleDetailReactor(provider: provider)
+		let reactor = MiddleDetailReactor(provider: self.dependency.serviceBuilder.provider)
 		let vc = MiddleDetailViewContorller(with: reactor)
 		self.rootViewController.visibleViewController?.present(vc, animated: true)
 		return .one(flowContributor: .contribute(withNextPresentable: vc,

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/MiddleFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/MiddleFlow.swift
@@ -91,11 +91,10 @@ private extension MiddleFlow {
 	}
 	
 	func presentMiddleDetail() -> FlowContributors {
-		let reactor = MiddleDetailReactor(provider: self.dependency.serviceBuilder.provider)
-		let vc = MiddleDetailViewContorller(with: reactor)
+		let vc = self.dependency.detailBuilder.viewController
 		self.rootViewController.visibleViewController?.present(vc, animated: true)
 		return .one(flowContributor: .contribute(withNextPresentable: vc,
-																						 withNextStepper: reactor))
+																						 withNextStepper: vc.reactor!))
 	}
 	
 	func dismissVC() -> FlowContributors {

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/MiddleFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/MiddleFlow.swift
@@ -76,11 +76,10 @@ final class MiddleFlow: Flow {
 
 private extension MiddleFlow {
 	func coordinateToMiddle() -> FlowContributors {
-		let reactor = MiddleReactor(provider: self.dependency.serviceBuilder.provider)
-		let vc = MiddleViewController(with: reactor)
+		let vc = self.dependency.middleBuilder.viewController
 		self.rootViewController.setViewControllers([vc], animated: true)
 		return .one(flowContributor: .contribute(withNextPresentable: vc,
-																						 withNextStepper: reactor))
+																						 withNextStepper: vc.reactor!))
 	}
 	
 	func coordinateToMiddleFirst() -> FlowContributors {

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/SettingFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/SettingFlow.swift
@@ -64,11 +64,10 @@ final class SettingFlow: Flow {
 
 private extension SettingFlow {
 	func coordinateToSetting() -> FlowContributors {
-		let reactor = SettingReactor(provider: self.dependency.serviceBuilder.provider)
-		let vc = SettingViewController(with: reactor)
+		let vc = self.dependency.builder.viewController
 		self.rootViewController.setViewControllers([vc], animated: true)
 		return .one(flowContributor: .contribute(withNextPresentable: vc,
-																						 withNextStepper: reactor))
+																						 withNextStepper: vc.reactor!))
 	}
 	
 	func navigateToAlertScreen(message: String) -> FlowContributors {

--- a/starter/RxFlowWithReactorKit/Sources/Flows/Main/SettingFlow.swift
+++ b/starter/RxFlowWithReactorKit/Sources/Flows/Main/SettingFlow.swift
@@ -26,15 +26,15 @@ final class SettingFlow: Flow {
 	private let rootViewController = UINavigationController()
 	let stepper: SettingStepper
 	
-	private let provider: ServiceProviderType
+	private let dependency: SettingFlowComponent
 	
 	// MARK: Init
 	
 	init(
-		with services: ServiceProviderType,
+		dependency: SettingFlowComponent,
 		stepper: SettingStepper
 	) {
-		self.provider = services
+		self.dependency = dependency
 		self.stepper = stepper
 	}
 	
@@ -64,7 +64,7 @@ final class SettingFlow: Flow {
 
 private extension SettingFlow {
 	func coordinateToSetting() -> FlowContributors {
-		let reactor = SettingReactor(provider: provider)
+		let reactor = SettingReactor(provider: self.dependency.serviceBuilder.provider)
 		let vc = SettingViewController(with: reactor)
 		self.rootViewController.setViewControllers([vc], animated: true)
 		return .one(flowContributor: .contribute(withNextPresentable: vc,


### PR DESCRIPTION
> RootComponent를 시작점으로 각 클래스에 필요한 의존성을 연결 받는 형태로 변경했어요.

### 의존성 그래프:
<img width="401" alt="스크린샷 2022-04-02 오후 4 14 19" src="https://user-images.githubusercontent.com/19662529/161371900-ac4a9d30-da10-4049-88f4-4949a06b4bb1.png">

### Tips:
1. flowsContributor를 넘길때 builder에서 가져온 viewController의 reactor를 넣어줘야해요. reactor를 빌더에서 따로 생성하게 되면 클래스의 주소가 달라 stepper가 의도대로 동작하지 않습니다.
2. Flow에 필요한 dependency는 component 자체를 넘겨주게끔 구성했어요. 구조가 매끄럽지 않으니 중간에 별도의 컴포넌트를 만드는 방법도 고민해보고있어요.
3. AppFlow는 앱의 시작점이라 window를 어떻게 넣어줄지 고민이 많았어요. RootComponent에서 생성자로 넘기게 되면 테스트코드에서도 UIWindow 의존성이 발생하게 되어 단위테스트에도 좋지 않은 구조가 될 것 같았어요. 그래서 RIBs의 Router를 참고하여 launch 메소드를 별도로 만들었어요. (아마 구조가 립스랑 비슷하게 변경될 것만 같은 느낌이 들어요 😓)

### Todo:
- [ ] : Stepper는 어디서 주입할건지 고민해봐요.
- [ ] : Reactor도 컴포넌트를 사용해서 만들지 고려해보도록 해요.
